### PR TITLE
ci: add workflow that bumps sdk in other asyncapi projects

### DIFF
--- a/.github/workflows/bump.yml
+++ b/.github/workflows/bump.yml
@@ -1,0 +1,32 @@
+name: Bump package version in dependent repos
+
+on:
+  #It cannot run on release event as when release is created then version is not yet bumped in package.json
+  #This means we cannot extract easily latest version and have a risk that package is not yet on npm
+  push:
+    branches:
+      - master
+
+jobs:
+  bump:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v2
+      - name: Get version from package.json before release step
+        id: extractver
+        run: echo "::set-output name=version::$(npm run get-version --silent)"
+      - name: Get name of package from package.json
+        id: extractname
+        run: echo "::set-output name=packname::$(npm run get-name --silent)"
+      - if: startsWith(github.event.commits[0].message, ' chore(release):')
+        name: Bumping latest version of this package in other repositories
+        uses: derberg/org-projects-dependency-manager@v1
+        with:
+          github_token: ${{ secrets.GH_TOKEN }}
+          committer_username: asyncapi-bot
+          committer_email: info@asyncapi.io
+          #This is commit message and PR title for repos where this package is in dependencies
+          commit_message_prod: 'fix: update ${{ steps.extractname.outputs.packname }} to ${{ steps.extractver.outputs.version }} version'
+          #This is commit message and PR title for repos where this package is in devDependencies
+          commit_message_dev: 'chore: update ${{ steps.extractname.outputs.packname }} to ${{ steps.extractver.outputs.version }} version'

--- a/README.md
+++ b/README.md
@@ -53,9 +53,7 @@ Restrictions:
 
 ### The debug flag
 
-When rendering you have the option of passing a `debug` flag which does
-
-* Does not remove the transpiled files after the rendering process is done.
+When rendering you have the option of passing a `debug` flag which does not remove the transpiled files after the rendering process is done.
 
 ## Example
 

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "lint": "eslint --max-warnings 0 --config .eslintrc .",
     "lint:fix": "eslint --max-warnings 0 --config .eslintrc . --fix",
     "get-version": "echo $npm_package_version",
+    "get-name": "echo $npm_package_name",
     "release": "semantic-release"
   },
   "eslintConfig": {


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

Like in the title, except for the fact that of course bumps will be performed in the future, once there are package dependent on sdk :trollface: 

- added new bump workflow
- missing scripts
- some readme error

**Related issue(s)**
See also https://github.com/asyncapi/.github/issues/16