### PR TITLE
fix: compare File component by name not by reference

### DIFF
--- a/src/renderer/template.ts
+++ b/src/renderer/template.ts
@@ -1,7 +1,6 @@
 import React from "react";
 
 import { render } from "./renderer";
-import { File } from "../components";
 import { isJsFile } from "../utils";
 import { TemplateContext, TemplateRenderResult } from "../types";
 
@@ -48,7 +47,7 @@ function renderFile(file: React.ReactElement): TemplateRenderResult | undefined 
   const { type, props = {} } = file;
 
   // if no File component is found as root, don't render it.
-  if (type !== File) {
+  if (typeof type !== "function" || type.name !== "File") {
     return undefined;
   }
 


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

Generator has always another reference to `File` component than templates, so changed comparison was always false. In local dev it worked, so bug hadn't been noticed before.