### PR TITLE
fix: reimport file on each render

### DIFF
--- a/src/renderer/template.ts
+++ b/src/renderer/template.ts
@@ -13,7 +13,14 @@ export async function renderTemplate(filepath: string, context: TemplateContext)
   if (!isJsFile(filepath)) {
     return undefined;
   }
-  const data = await importComponent(filepath, context);
+
+  let data = undefined;
+  try {
+    data = await importComponent(filepath, context);
+  } catch(err) {
+    console.error(err);
+    return undefined;
+  }
 
   // undefined, null etc. cases
   if (!data) {
@@ -28,10 +35,23 @@ export async function renderTemplate(filepath: string, context: TemplateContext)
  * @private
  * @param filepath to import
  */
-function importComponent(filepath: string, context: TemplateContext): Promise<React.ReactElement> {
-  return new Promise((resolve) => {
-    import(filepath).then(component => { resolve(component.default !== undefined ? component.default(context) : undefined) })
-  })
+function importComponent(filepath: string, context: TemplateContext): Promise<React.ReactElement | undefined> {
+  return new Promise((resolve, reject) => {
+    try {
+      // we should import component only in NodeJS
+      if (require === undefined) resolve(undefined);
+      // remove from cache imported file
+      delete require.cache[require.resolve(filepath)];
+
+      const component = require(filepath);
+      if (!component) resolve(undefined);
+      if (typeof component === "function") resolve(component(context));
+      if (typeof component.default === "function") resolve(component.default(context));
+      resolve(undefined);
+    } catch(err) {
+      reject(err);
+    }
+  });
 }
 
 /**

--- a/src/renderer/template.ts
+++ b/src/renderer/template.ts
@@ -44,7 +44,6 @@ function importComponent(filepath: string, context: TemplateContext): Promise<Re
       delete require.cache[require.resolve(filepath)];
 
       const component = require(filepath);
-      if (!component) resolve(undefined);
       if (typeof component === "function") resolve(component(context));
       if (typeof component.default === "function") resolve(component.default(context));
       resolve(undefined);

--- a/src/renderer/template.ts
+++ b/src/renderer/template.ts
@@ -18,8 +18,7 @@ export async function renderTemplate(filepath: string, context: TemplateContext)
   try {
     data = await importComponent(filepath, context);
   } catch(err) {
-    console.error(err);
-    return undefined;
+    throw err;
   }
 
   // undefined, null etc. cases


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

We have a bug inside the SDK. If we turn generator in `--watch-template` mode then with current implementation React-SDK render imported template file (component) from cache. This PR fixes it. 

**Related issue(s)**
Part of https://github.com/asyncapi/generator/issues/465