### PR TITLE
feat: integrate context feature

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,0 +1,1 @@
+export const PROVIDER_SYMBOL = Symbol("Provider");

--- a/src/context/__tests__/context.spec.tsx
+++ b/src/context/__tests__/context.spec.tsx
@@ -1,0 +1,90 @@
+import React from 'react';
+import { createContext, useContext } from "../";
+import { render } from "../..";
+
+describe('Context', () => {
+  test('should context works in basic case', () => {
+    interface Values {
+      prop: string
+    }
+    const Context = createContext<Values>();
+
+    function Component() {
+      const ctx = useContext(Context);
+      return <>{ctx.prop}</>;
+    }
+
+    const template = (
+      <Context.Provider value={{ prop: "someValue" }}>
+        <Component />
+      </Context.Provider>
+    );
+
+    const content = render(template);
+    expect(content).toEqual("someValue");
+  });
+
+  test('should devaultValue works', () => {
+    interface Values {
+      prop: string
+    }
+    const Context = createContext<Values>({ prop: "default" });
+
+    function Component() {
+      const ctx = useContext(Context);
+      return <>{ctx.prop}</>;
+    }
+
+    const content = render(<Component />);
+    expect(content).toEqual("default");
+  });
+
+  test('should context works in complex JSX stucture', () => {
+    interface Values {
+      prop: string
+    }
+    const ParentContext = createContext<Values>();
+    const ChildContext = createContext<Values>();
+
+    function Component() {
+      const parent = useContext(ParentContext);
+      const child = useContext(ChildContext);
+
+      return <>{child.prop} {parent.prop}</>;
+    }
+
+    const template = (
+      <ParentContext.Provider value={{ prop: "parent" }}>
+        <ChildContext.Provider value={{ prop: "child" }}>
+          <Component />
+        </ChildContext.Provider>
+      </ParentContext.Provider>
+    );
+
+    const content = render(template);
+    expect(content).toEqual("child parent");
+  });
+
+  test('should ovveride works', () => {
+    interface Values {
+      prop: string
+    }
+    const Context = createContext<Values>();
+
+    function Component() {
+      const ctx = useContext(Context);
+      return <>{ctx.prop}</>;
+    }
+
+    const template = (
+      <Context.Provider value={{ prop: "parent" }}>
+        <Context.Provider value={{ prop: "child" }}>
+          <Component />
+        </Context.Provider>
+      </Context.Provider>
+    );
+
+    const content = render(template);
+    expect(content).toEqual("child");
+  });
+});

--- a/src/context/index.ts
+++ b/src/context/index.ts
@@ -1,0 +1,50 @@
+import { render } from "../renderer";
+import { PROVIDER_SYMBOL } from "../constants";
+
+export interface Context<T> {
+  id: symbol;
+  Provider: (props: { value: T; children: any }) => any;
+  defaultValue?: T;
+}
+
+export function createContext<T>(defaultValue?: T): Context<T> {
+  const id = Symbol("context");
+  return { id, Provider: createProvider(id), defaultValue };
+}
+
+interface CurrentContext<T = any> {
+  id: symbol | null;
+  value: any;
+  parent: CurrentContext | null,
+}
+let currentContext: CurrentContext = { id: null, value: undefined, parent: null };
+
+export function useContext<T>(context: Context<T>): T {
+  return lookupContext(currentContext, context.id)?.value || context.defaultValue;
+}
+
+function createProvider(id: symbol) {
+  const fn = function provider(props: { value: unknown; children: any }) {
+    const previous = setCurrentContext(id, props.value)
+    try {
+      return render(props.children);
+    } finally {
+      currentContext = previous;
+    }
+  };
+  fn.$$typeof = PROVIDER_SYMBOL;
+  return fn;
+}
+
+function lookupContext(current: CurrentContext, id: symbol): CurrentContext | null {
+  if (current.id === id) {
+    return current;
+  }
+  return current.parent && lookupContext(current.parent, id);
+}
+
+function setCurrentContext(id: symbol, value: unknown): CurrentContext {
+  const previous = currentContext;
+  currentContext = { id, value, parent: previous };
+  return previous;
+}

--- a/src/renderer/renderer.ts
+++ b/src/renderer/renderer.ts
@@ -1,3 +1,4 @@
+import { PROVIDER_SYMBOL } from "../constants";
 import { PropsWithChildrenContent } from "../types";
 
 /**
@@ -43,7 +44,14 @@ function createElement(element: React.ReactElement): React.ReactElement | string
       return createElement(clazzComp.render());
     }
     // Function component case
-    return createElement(type(normalizeProps(element.props)));
+    switch(type.$$typeof) {
+      case PROVIDER_SYMBOL: {
+        return createElement(type(element.props));
+      }
+      default: {
+        return createElement(type(normalizeProps(element.props)));
+      }
+    }
   }
 
   return element || "";


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

Integrate context feature inside React renderer:
- create `createContext` and `useContent` functions (similar logic like in normal React),
- update `createElement` function to handle context,
- write unit tests.

NOTE: This feature at the moment doesn't work in asynchronous code, because context like in React operates on global currentContext/currentDispatcher. I'll think how to handle parallel case.

**Related issue(s)**
Resolves https://github.com/asyncapi/generator-react-sdk/issues/18
See also https://github.com/asyncapi/shape-up-process/issues/54