### PR TITLE
fix: render async templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,10 @@ The process of creating content from React components consists of two main proce
 
 The SDK has a custom transpiler which ensures that any directory are transpiled using [Rollup](https://www.npmjs.com/package/rollup). Rollup helps bundling all dependencies and transpile them into CommonJS modules. This is required because this library will be used through NodeJS which does not understand these new modules natively and we do not want to limit the developer in which syntax they prefer nor how they want to separate code.
 
+#### Requirements for transpilation
+
+* Node.js v12.16 and higher
+
 ### The Rendering Process
 
 SDK has its own reconciler for React components. It traverses through each element in the template structure and transforms it into a pure string. Additionally, prop `children` is also converted to a regular string and stored in the` childrenContent` prop, which is appended to each component. See [example](#example).

--- a/README.md
+++ b/README.md
@@ -26,10 +26,6 @@ AsyncAPI React SDK is a set of components/functions to use React as render engin
 
 <!-- tocstop -->
 
-## Requirements
-
-* Node.js v12.16 and higher
-
 ## Installation
 
 Run this command to install the SDK in your project:
@@ -55,6 +51,12 @@ Restrictions:
 - React hooks is not allowed.
 - HTML tags at the moment is not supported.
 - React internal components like Fragments, Suspense etc. are skipped.
+
+#### Requirements
+
+To render the transpiled template SDK requires:
+
+* Node.js v12.16 and higher
 
 ## The debug flag
 

--- a/README.md
+++ b/README.md
@@ -26,6 +26,10 @@ AsyncAPI React SDK is a set of components/functions to use React as render engin
 
 <!-- tocstop -->
 
+## Requirements
+
+* Node.js v12.16 and higher
+
 ## Installation
 
 Run this command to install the SDK in your project:
@@ -41,10 +45,6 @@ The process of creating content from React components consists of two main proce
 ### The Transpile Process
 
 The SDK has a custom transpiler which ensures that any directory are transpiled using [Rollup](https://www.npmjs.com/package/rollup). Rollup helps bundling all dependencies and transpile them into CommonJS modules. This is required because this library will be used through NodeJS which does not understand these new modules natively and we do not want to limit the developer in which syntax they prefer nor how they want to separate code.
-
-#### Requirements for transpilation
-
-* Node.js v12.16 and higher
 
 ### The Rendering Process
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ AsyncAPI React SDK is a set of components/functions to use React as render engin
 - [How it works](#how-it-works)
   * [The Transpile Process](#the-transpile-process)
   * [The Rendering Process](#the-rendering-process)
+    + [Requirements](#requirements)
 - [The debug flag](#the-debug-flag)
 - [Example](#example)
 - [Resources](#resources)

--- a/src/renderer/__tests__/file-tests/async-template.js
+++ b/src/renderer/__tests__/file-tests/async-template.js
@@ -1,0 +1,8 @@
+/* eslint-disable */
+
+const React = require('react');
+const { File } = require('../../../components');
+
+module.exports = async function() {
+  return React.createElement(File, { name: 'file.html' }, ['Content']);
+};

--- a/src/renderer/__tests__/template.spec.ts
+++ b/src/renderer/__tests__/template.spec.ts
@@ -24,4 +24,13 @@ describe('renderTemplate', () => {
     expect(renderedContent[1].content).toEqual('Content2');
     expect(renderedContent[1].metadata.fileName).toEqual('file2.html');
   });
+
+  test('should render a single async File template', async () => {
+    const filePath = path.resolve(__dirname, './file-tests/async-template.js');
+    const renderedContent = await renderTemplate(filePath, {} as any) as TemplateRenderResult;
+
+    expect(typeof renderedContent).toEqual('object');
+    expect(renderedContent.content).toEqual('Content');
+    expect(renderedContent.metadata.fileName).toEqual('file.html');
+  });
 });

--- a/src/transpiler/__tests__/__snapshots__/transpiler.spec.tsx.snap
+++ b/src/transpiler/__tests__/__snapshots__/transpiler.spec.tsx.snap
@@ -7,15 +7,16 @@ var jsxRuntime = require('react/jsx-runtime');
 require('source-map-support/register');
 
 /* eslint-disable no-undef */
-var path = require('path'); // this weird import are only necessary because we test within the SDK itself.
+const path = require('path'); // this weird import are only necessary because we test within the SDK itself.
 // eslint-disable-next-line security/detect-non-literal-require
 
 
-var _require = require(path.resolve(__dirname, '../../../../components')),
-    File = _require.File;
+const {
+  File
+} = require(path.resolve(__dirname, '../../../../components'));
 
 function greetings(name) {
-  return \\"hello \\".concat(name);
+  return \`hello \${name}\`;
 } // eslint-disable-next-line react/display-name
 
 
@@ -28,7 +29,7 @@ module.exports = function () {
 "
 `;
 
-exports[`Transpiler should transpile CommonJS files with a simple setup and import correctly 2`] = `"{\\"version\\":3,\\"file\\":\\"simple.js\\",\\"sources\\":[\\"../../testfiles/CommonJS/simple.js\\"],\\"sourcesContent\\":[\\"/* eslint-disable no-undef */\\\\nconst path = require('path');\\\\n// this weird import are only necessary because we test within the SDK itself.\\\\n// eslint-disable-next-line security/detect-non-literal-require\\\\nconst {File} = require(path.resolve(__dirname, '../../../../components'));\\\\nfunction greetings(name) {\\\\n  return \`hello \${name}\`;\\\\n}\\\\n// eslint-disable-next-line react/display-name\\\\nmodule.exports = function() {\\\\n  return (\\\\n    <File>\\\\n      {greetings('Test')}\\\\n    </File>\\\\n  );\\\\n};\\"],\\"names\\":[\\"path\\",\\"require\\",\\"resolve\\",\\"__dirname\\",\\"File\\",\\"greetings\\",\\"name\\",\\"module\\",\\"exports\\",\\"_jsx\\"],\\"mappings\\":\\";;;;;AAAA;AACA,IAAMA,IAAI,GAAGC,OAAO,CAAC,MAAD,CAApB;AAEA;;;eACeA,OAAO,CAACD,IAAI,CAACE,OAAL,CAAaC,SAAb,EAAwB,wBAAxB,CAAD;IAAfC,gBAAAA;;AACP,SAASC,SAAT,CAAmBC,IAAnB,EAAyB;AACvB,yBAAgBA,IAAhB;AACD;;;AAEDC,MAAM,CAACC,OAAP,GAAiB,YAAW;AAC1B,sBACEC,eAAC,IAAD;AAAA,cACGJ,SAAS,CAAC,MAAD;AADZ,IADF;AAKD,CAND;;\\"}"`;
+exports[`Transpiler should transpile CommonJS files with a simple setup and import correctly 2`] = `"{\\"version\\":3,\\"file\\":\\"simple.js\\",\\"sources\\":[\\"../../testfiles/CommonJS/simple.js\\"],\\"sourcesContent\\":[\\"/* eslint-disable no-undef */\\\\nconst path = require('path');\\\\n// this weird import are only necessary because we test within the SDK itself.\\\\n// eslint-disable-next-line security/detect-non-literal-require\\\\nconst {File} = require(path.resolve(__dirname, '../../../../components'));\\\\nfunction greetings(name) {\\\\n  return \`hello \${name}\`;\\\\n}\\\\n// eslint-disable-next-line react/display-name\\\\nmodule.exports = function() {\\\\n  return (\\\\n    <File>\\\\n      {greetings('Test')}\\\\n    </File>\\\\n  );\\\\n};\\"],\\"names\\":[\\"path\\",\\"require\\",\\"File\\",\\"resolve\\",\\"__dirname\\",\\"greetings\\",\\"name\\",\\"module\\",\\"exports\\",\\"_jsx\\"],\\"mappings\\":\\";;;;;AAAA;AACA,MAAMA,IAAI,GAAGC,OAAO,CAAC,MAAD,CAApB;AAEA;;;AACA,MAAM;AAACC,EAAAA;AAAD,IAASD,OAAO,CAACD,IAAI,CAACG,OAAL,CAAaC,SAAb,EAAwB,wBAAxB,CAAD,CAAtB;;AACA,SAASC,SAAT,CAAmBC,IAAnB,EAAyB;AACvB,SAAQ,SAAQA,IAAK,EAArB;AACD;;;AAEDC,MAAM,CAACC,OAAP,GAAiB,YAAW;AAC1B,sBACEC,eAAC,IAAD;AAAA,cACGJ,SAAS,CAAC,MAAD;AADZ,IADF;AAKD,CAND;;\\"}"`;
 
 exports[`Transpiler should transpile ES5 files with a simple setup and import correctly 1`] = `
 "'use strict';
@@ -43,11 +44,12 @@ var path__default = /*#__PURE__*/_interopDefaultLegacy(path);
 
 // eslint-disable-next-line security/detect-non-literal-require, no-undef
 
-var _require = require(path__default['default'].resolve(__dirname, '../../../../components')),
-    File = _require.File;
+const {
+  File
+} = require(path__default['default'].resolve(__dirname, '../../../../components'));
 
 function greetings(name) {
-  return \\"hello \\".concat(name);
+  return \`hello \${name}\`;
 } // eslint-disable-next-line react/display-name
 
 
@@ -62,7 +64,7 @@ module.exports = simple;
 "
 `;
 
-exports[`Transpiler should transpile ES5 files with a simple setup and import correctly 2`] = `"{\\"version\\":3,\\"file\\":\\"simple.js\\",\\"sources\\":[\\"../../testfiles/ES5/simple.js\\"],\\"sourcesContent\\":[\\"import path from 'path';\\\\n// this weird import are only necessary because we test within the SDK itself.\\\\n// eslint-disable-next-line security/detect-non-literal-require, no-undef\\\\nconst {File} = require(path.resolve(__dirname, '../../../../components'));\\\\nfunction greetings(name) {\\\\n  return \`hello \${name}\`;\\\\n}\\\\n// eslint-disable-next-line react/display-name\\\\nexport default function() {\\\\n  return (\\\\n    <File>\\\\n      {greetings('Test')}\\\\n    </File>\\\\n  );\\\\n}\\"],\\"names\\":[\\"require\\",\\"path\\",\\"resolve\\",\\"__dirname\\",\\"File\\",\\"greetings\\",\\"name\\",\\"_jsx\\"],\\"mappings\\":\\";;;;;;;;;;AAEA;;eACeA,OAAO,CAACC,wBAAI,CAACC,OAAL,CAAaC,SAAb,EAAwB,wBAAxB,CAAD;IAAfC,gBAAAA;;AACP,SAASC,SAAT,CAAmBC,IAAnB,EAAyB;AACvB,yBAAgBA,IAAhB;AACD;;;AAEc,mBAAW;AACxB,sBACEC,eAAC,IAAD;AAAA,cACGF,SAAS,CAAC,MAAD;AADZ,IADF;AAKD;;;;\\"}"`;
+exports[`Transpiler should transpile ES5 files with a simple setup and import correctly 2`] = `"{\\"version\\":3,\\"file\\":\\"simple.js\\",\\"sources\\":[\\"../../testfiles/ES5/simple.js\\"],\\"sourcesContent\\":[\\"import path from 'path';\\\\n// this weird import are only necessary because we test within the SDK itself.\\\\n// eslint-disable-next-line security/detect-non-literal-require, no-undef\\\\nconst {File} = require(path.resolve(__dirname, '../../../../components'));\\\\nfunction greetings(name) {\\\\n  return \`hello \${name}\`;\\\\n}\\\\n// eslint-disable-next-line react/display-name\\\\nexport default function() {\\\\n  return (\\\\n    <File>\\\\n      {greetings('Test')}\\\\n    </File>\\\\n  );\\\\n}\\"],\\"names\\":[\\"File\\",\\"require\\",\\"path\\",\\"resolve\\",\\"__dirname\\",\\"greetings\\",\\"name\\",\\"_jsx\\"],\\"mappings\\":\\";;;;;;;;;;AAEA;;AACA,MAAM;AAACA,EAAAA;AAAD,IAASC,OAAO,CAACC,wBAAI,CAACC,OAAL,CAAaC,SAAb,EAAwB,wBAAxB,CAAD,CAAtB;;AACA,SAASC,SAAT,CAAmBC,IAAnB,EAAyB;AACvB,SAAQ,SAAQA,IAAK,EAArB;AACD;;;AAEc,mBAAW;AACxB,sBACEC,eAAC,IAAD;AAAA,cACGF,SAAS,CAAC,MAAD;AADZ,IADF;AAKD;;;;\\"}"`;
 
 exports[`Transpiler should transpile ES6 files with a simple setup and import correctly 1`] = `
 "'use strict';
@@ -77,12 +79,11 @@ var path__default = /*#__PURE__*/_interopDefaultLegacy(path);
 
 // eslint-disable-next-line security/detect-non-literal-require, no-undef
 
-var _require = require(path__default['default'].resolve(__dirname, '../../../../components')),
-    File = _require.File;
+const {
+  File
+} = require(path__default['default'].resolve(__dirname, '../../../../components'));
 
-var greetings = function greetings(name) {
-  return \\"hello \\".concat(name);
-}; // eslint-disable-next-line react/display-name
+const greetings = name => \`hello \${name}\`; // eslint-disable-next-line react/display-name
 
 
 function simple () {
@@ -96,4 +97,4 @@ module.exports = simple;
 "
 `;
 
-exports[`Transpiler should transpile ES6 files with a simple setup and import correctly 2`] = `"{\\"version\\":3,\\"file\\":\\"simple.js\\",\\"sources\\":[\\"../../testfiles/ES6/simple.js\\"],\\"sourcesContent\\":[\\"import path from 'path';\\\\n// this weird import are only necessary because we test within the SDK itself.\\\\n// eslint-disable-next-line security/detect-non-literal-require, no-undef\\\\nconst {File} = require(path.resolve(__dirname, '../../../../components'));\\\\nconst greetings = name => \`hello \${name}\`;\\\\n// eslint-disable-next-line react/display-name\\\\nexport default function() {\\\\n  return (\\\\n    <File>\\\\n      {greetings('Test')}\\\\n    </File>\\\\n  );\\\\n}\\"],\\"names\\":[\\"require\\",\\"path\\",\\"resolve\\",\\"__dirname\\",\\"File\\",\\"greetings\\",\\"name\\",\\"_jsx\\"],\\"mappings\\":\\";;;;;;;;;;AAEA;;eACeA,OAAO,CAACC,wBAAI,CAACC,OAAL,CAAaC,SAAb,EAAwB,wBAAxB,CAAD;IAAfC,gBAAAA;;AACP,IAAMC,SAAS,GAAG,SAAZA,SAAY,CAAAC,IAAI;AAAA,yBAAaA,IAAb;AAAA,CAAtB;;;AAEe,mBAAW;AACxB,sBACEC,eAAC,IAAD;AAAA,cACGF,SAAS,CAAC,MAAD;AADZ,IADF;AAKD;;;;\\"}"`;
+exports[`Transpiler should transpile ES6 files with a simple setup and import correctly 2`] = `"{\\"version\\":3,\\"file\\":\\"simple.js\\",\\"sources\\":[\\"../../testfiles/ES6/simple.js\\"],\\"sourcesContent\\":[\\"import path from 'path';\\\\n// this weird import are only necessary because we test within the SDK itself.\\\\n// eslint-disable-next-line security/detect-non-literal-require, no-undef\\\\nconst {File} = require(path.resolve(__dirname, '../../../../components'));\\\\nconst greetings = name => \`hello \${name}\`;\\\\n// eslint-disable-next-line react/display-name\\\\nexport default function() {\\\\n  return (\\\\n    <File>\\\\n      {greetings('Test')}\\\\n    </File>\\\\n  );\\\\n}\\"],\\"names\\":[\\"File\\",\\"require\\",\\"path\\",\\"resolve\\",\\"__dirname\\",\\"greetings\\",\\"name\\",\\"_jsx\\"],\\"mappings\\":\\";;;;;;;;;;AAEA;;AACA,MAAM;AAACA,EAAAA;AAAD,IAASC,OAAO,CAACC,wBAAI,CAACC,OAAL,CAAaC,SAAb,EAAwB,wBAAxB,CAAD,CAAtB;;AACA,MAAMC,SAAS,GAAGC,IAAI,IAAK,SAAQA,IAAK,EAAxC;;;AAEe,mBAAW;AACxB,sBACEC,eAAC,IAAD;AAAA,cACGF,SAAS,CAAC,MAAD;AADZ,IADF;AAKD;;;;\\"}"`;

--- a/src/transpiler/transpiler.ts
+++ b/src/transpiler/transpiler.ts
@@ -27,16 +27,18 @@ export async function transpileFiles(directory: string, outputDir: string, optio
          */
         const bundles = await rollup({
             input: files,
-            onwarn: ()=>{},
+            onwarn: () => {},
             plugins: [
                 babel({
                     cwd: ROOT_DIR,
                     babelHelpers: "bundled",
                     plugins: [
-                        "source-map-support"
+                        "source-map-support",
                     ],
                     presets: [
-                        "@babel/preset-env",
+                        ["@babel/preset-env", {
+                            targets: { node: "14.16" },
+                        }],
                         ["@babel/preset-react", {
                             runtime: "automatic",
                         }],

--- a/src/transpiler/transpiler.ts
+++ b/src/transpiler/transpiler.ts
@@ -37,7 +37,7 @@ export async function transpileFiles(directory: string, outputDir: string, optio
                     ],
                     presets: [
                         ["@babel/preset-env", {
-                            targets: { node: "14.16" },
+                            targets: { node: "12.16" },
                         }],
                         ["@babel/preset-react", {
                             runtime: "automatic",

--- a/src/types.ts
+++ b/src/types.ts
@@ -20,6 +20,11 @@ export interface TemplateContext<P = Record<string, any>>{
 }
 
 /**
+ * Signature for template function
+ */
+export type TemplateFunction<R = React.ReactElement | undefined> = (context: TemplateContext) => R | Promise<R>;
+
+/**
  * Options for transpiling files.
  */
 export type TranspileFilesOptions = {


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

- await for async templates in rendering process,
- bump node version to `12.16` in transpilation process,
- add unit tests for missing feature.

**Related issue(s)**
Fixes https://github.com/asyncapi/generator-react-sdk/issues/42