### PR TITLE
fix: use production version of react/jsx-runtime

### DIFF
--- a/src/jsx-runtime.ts
+++ b/src/jsx-runtime.ts
@@ -1,2 +1,0 @@
-// @ts-ignore
-export * from 'react/cjs/react-jsx-runtime.production.min';

--- a/src/jsx-runtime.ts
+++ b/src/jsx-runtime.ts
@@ -1,0 +1,2 @@
+// @ts-ignore
+export * from 'react/cjs/react-jsx-runtime.production.min';

--- a/src/transpiler/__tests__/__snapshots__/transpiler.spec.tsx.snap
+++ b/src/transpiler/__tests__/__snapshots__/transpiler.spec.tsx.snap
@@ -3,7 +3,7 @@
 exports[`Transpiler should transpile CommonJS files with a simple setup and import correctly 1`] = `
 "'use strict';
 
-var jsxRuntime = require('react/jsx-runtime');
+var jsxRuntime = require('react/cjs/react-jsx-runtime.production.min');
 require('source-map-support/register');
 
 /* eslint-disable no-undef */
@@ -34,7 +34,7 @@ exports[`Transpiler should transpile CommonJS files with a simple setup and impo
 exports[`Transpiler should transpile ES5 files with a simple setup and import correctly 1`] = `
 "'use strict';
 
-var jsxRuntime = require('react/jsx-runtime');
+var jsxRuntime = require('react/cjs/react-jsx-runtime.production.min');
 require('source-map-support/register');
 var path = require('path');
 
@@ -69,7 +69,7 @@ exports[`Transpiler should transpile ES5 files with a simple setup and import co
 exports[`Transpiler should transpile ES6 files with a simple setup and import correctly 1`] = `
 "'use strict';
 
-var jsxRuntime = require('react/jsx-runtime');
+var jsxRuntime = require('react/cjs/react-jsx-runtime.production.min');
 require('source-map-support/register');
 var path = require('path');
 

--- a/src/transpiler/transpiler.ts
+++ b/src/transpiler/transpiler.ts
@@ -41,7 +41,6 @@ export async function transpileFiles(directory: string, outputDir: string, optio
                         }],
                         ["@babel/preset-react", {
                             runtime: "automatic",
-                            importSource: process.env.NODE_ENV === 'test' ? 'react' : "@asyncapi/generator-react-sdk/lib",
                         }],
                     ],
                 })
@@ -51,7 +50,10 @@ export async function transpileFiles(directory: string, outputDir: string, optio
             format: "commonjs",
             sourcemap: true,
             dir: outputDir,
-            exports: "auto"
+            exports: "auto",
+            paths: {
+              'react/jsx-runtime': 'react/cjs/react-jsx-runtime.production.min',
+            }
         })
     }
 

--- a/src/transpiler/transpiler.ts
+++ b/src/transpiler/transpiler.ts
@@ -41,6 +41,7 @@ export async function transpileFiles(directory: string, outputDir: string, optio
                         }],
                         ["@babel/preset-react", {
                             runtime: "automatic",
+                            importSource: "@asyncapi/generator-react-sdk/lib",
                         }],
                     ],
                 })

--- a/src/transpiler/transpiler.ts
+++ b/src/transpiler/transpiler.ts
@@ -41,7 +41,7 @@ export async function transpileFiles(directory: string, outputDir: string, optio
                         }],
                         ["@babel/preset-react", {
                             runtime: "automatic",
-                            importSource: "@asyncapi/generator-react-sdk/lib",
+                            importSource: process.env.NODE_ENV === 'test' ? 'react' : "@asyncapi/generator-react-sdk/lib",
                         }],
                     ],
                 })


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

Use production version of `react/jsx-runtime` to disable development warnings and also speed up the code. Change the `react/jsx-runtime` import to `react/cjs/react-jsx-runtime.production.min` in transpiled bundle.

How to test (in easiest way):
- link or install locally this package from my PR in `@asyncapi/generator` package
- test `@asyncapi/markdown-template` template and you shouldn't see any warnings related to *key* props.

**Related issue(s)**
Resolves https://github.com/asyncapi/generator-react-sdk/issues/37