### PR TITLE
fix: render array node

### DIFF
--- a/src/renderer/__tests__/renderer.spec.tsx
+++ b/src/renderer/__tests__/renderer.spec.tsx
@@ -106,6 +106,22 @@ describe('Renderer', () => {
     expect(content).toEqual("some text");
   });
 
+  test('should works with array as returned value', () => {
+    function Component({ text }: { text: string }) {
+      return <>{text}</>
+    }
+
+    function Test() {
+      return [
+        <Component text={'some'} />,
+        <Component text={' text'} />,
+        <Component text={' is rendered'} />,
+      ] as any;
+    }
+
+    const content = render(<Test />);
+    expect(content).toEqual("some text is rendered");
+  });
   
   test('should throws error due to using React hooks', () => {
     function Component() {

--- a/src/renderer/renderer.ts
+++ b/src/renderer/renderer.ts
@@ -46,7 +46,7 @@ function createElement(element: React.ReactElement): React.ReactElement | string
     return createElement(type(normalizeProps(element.props)));
   }
 
-  return element || "";
+  return render(element) || "";
 }
 
 /**


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

Fix rendering of array node. Atm if I return from component the array of components (what react supports), the rendered content will be something like that: `[Object object], [Object object], ...`. Try this example to show that bug:

```tsx
function Component({ text }: { text: string }) {
  return <>{text}</>
}

function Test() {
  return [
    <Component text={'some'} />,
    <Component text={' text'} />,
    <Component text={' is rendered'} />,
  ] as any;
}

const content = render(<Test />);
```