### PR TITLE
fix: `ERR_PACKAGE_PATH_NOT_EXPORTED` when react 18 is installed in project

### DIFF
--- a/src/transpiler/__tests__/__snapshots__/transpiler.spec.tsx.snap
+++ b/src/transpiler/__tests__/__snapshots__/transpiler.spec.tsx.snap
@@ -3,7 +3,7 @@
 exports[`Transpiler should keep names of files, even if special chars with a simple setup and import correctly 1`] = `
 "'use strict';
 
-var jsxRuntime = require('react/cjs/react-jsx-runtime.production.min');
+var jsxRuntime = require('/full/path/to/react/cjs/react-jsx-runtime.production.min.js');
 require('source-map-support/register');
 var path = require('path');
 
@@ -36,7 +36,7 @@ exports[`Transpiler should keep names of files, even if special chars with a sim
 exports[`Transpiler should transpile CommonJS files with a simple setup and import correctly 1`] = `
 "'use strict';
 
-var jsxRuntime = require('react/cjs/react-jsx-runtime.production.min');
+var jsxRuntime = require('/full/path/to/react/cjs/react-jsx-runtime.production.min.js');
 require('source-map-support/register');
 
 /* eslint-disable no-undef */
@@ -67,7 +67,7 @@ exports[`Transpiler should transpile CommonJS files with a simple setup and impo
 exports[`Transpiler should transpile ES5 files with a simple setup and import correctly 1`] = `
 "'use strict';
 
-var jsxRuntime = require('react/cjs/react-jsx-runtime.production.min');
+var jsxRuntime = require('/full/path/to/react/cjs/react-jsx-runtime.production.min.js');
 require('source-map-support/register');
 var path = require('path');
 
@@ -102,7 +102,7 @@ exports[`Transpiler should transpile ES5 files with a simple setup and import co
 exports[`Transpiler should transpile ES6 files with a simple setup and import correctly 1`] = `
 "'use strict';
 
-var jsxRuntime = require('react/cjs/react-jsx-runtime.production.min');
+var jsxRuntime = require('/full/path/to/react/cjs/react-jsx-runtime.production.min.js');
 require('source-map-support/register');
 var path = require('path');
 

--- a/src/transpiler/__tests__/transpiler.spec.tsx
+++ b/src/transpiler/__tests__/transpiler.spec.tsx
@@ -114,6 +114,10 @@ function switchToUnixLinebreaks(str: String) {
   return str.replace(/\\r/g, "")
 }
 
+/*
+  The transpiler embeds the absolute path to the react library.
+  We need to replace this in snapshots with something that will be stable across developer environments.
+*/
 function stripAbsolutePathToReactLib(str: String) {
   const reactPath = require.resolve('react/cjs/react-jsx-runtime.production.min')
   return str.replace(reactPath, "/full/path/to/react/cjs/react-jsx-runtime.production.min.js")

--- a/src/transpiler/__tests__/transpiler.spec.tsx
+++ b/src/transpiler/__tests__/transpiler.spec.tsx
@@ -32,9 +32,9 @@ describe('Transpiler', () => {
 
       test('and import correctly', async () => {
         const content = await readFile(commonjs_testFile, 'utf8');
-        expect(switchToUnixLinebreaks(content)).toMatchSnapshot();
+        expect(stripAbsolutePathToReactLib(switchToUnixLinebreaks(content))).toMatchSnapshot();
         const mapContent = await readFile(commonjs_testFileMap, 'utf8');
-        expect(switchToUnixLinebreaks(mapContent)).toMatchSnapshot();
+        expect(stripAbsolutePathToReactLib(switchToUnixLinebreaks(mapContent))).toMatchSnapshot();
         expect(await import(commonjs_testFile)).toBeDefined();
       });
 
@@ -52,9 +52,9 @@ describe('Transpiler', () => {
 
       test('and import correctly', async () => {
         const content = await readFile(es5_testFile, 'utf8')
-        expect(switchToUnixLinebreaks(content)).toMatchSnapshot();
+        expect(stripAbsolutePathToReactLib(switchToUnixLinebreaks(content))).toMatchSnapshot();
         const mapContent = await readFile(es5_testFileMap, 'utf8');
-        expect(switchToUnixLinebreaks(mapContent)).toMatchSnapshot();
+        expect(stripAbsolutePathToReactLib(switchToUnixLinebreaks(mapContent))).toMatchSnapshot();
         expect(await import(es5_testFile)).toBeDefined();
       });
 
@@ -72,9 +72,9 @@ describe('Transpiler', () => {
 
       test('and import correctly', async () => {
         const content = await readFile(es6_testFile, 'utf8')
-        expect(switchToUnixLinebreaks(content)).toMatchSnapshot();
+        expect(stripAbsolutePathToReactLib(switchToUnixLinebreaks(content))).toMatchSnapshot();
         const mapContent = await readFile(es6_testFileMap, 'utf8');
-        expect(switchToUnixLinebreaks(mapContent)).toMatchSnapshot();
+        expect(stripAbsolutePathToReactLib(switchToUnixLinebreaks(mapContent))).toMatchSnapshot();
         expect(await import(es6_testFile)).toBeDefined();
       });
 
@@ -92,9 +92,9 @@ describe('Transpiler', () => {
 
       test('and import correctly', async () => {
         const content = await readFile(special_testFile, 'utf8');
-        expect(switchToUnixLinebreaks(content)).toMatchSnapshot();
+        expect(stripAbsolutePathToReactLib(switchToUnixLinebreaks(content))).toMatchSnapshot();
         const mapContent = await readFile(special_testFileMap, 'utf8');
-        expect(switchToUnixLinebreaks(mapContent)).toMatchSnapshot();
+        expect(stripAbsolutePathToReactLib(switchToUnixLinebreaks(mapContent))).toMatchSnapshot();
         expect(await import(special_testFile)).toBeDefined();
       });
 
@@ -112,4 +112,9 @@ describe('Transpiler', () => {
 */
 function switchToUnixLinebreaks(str: String) {
   return str.replace(/\\r/g, "")
+}
+
+function stripAbsolutePathToReactLib(str: String) {
+  const reactPath = require.resolve('react/cjs/react-jsx-runtime.production.min')
+  return str.replace(reactPath, "/full/path/to/react/cjs/react-jsx-runtime.production.min.js")
 }

--- a/src/transpiler/transpiler.ts
+++ b/src/transpiler/transpiler.ts
@@ -52,7 +52,7 @@ export async function transpileFiles(directory: string, outputDir: string, optio
             dir: outputDir,
             exports: "auto",
             paths: {
-              'react/jsx-runtime': 'react/cjs/react-jsx-runtime.production.min',
+              'react/jsx-runtime': require.resolve('react/cjs/react-jsx-runtime.production.min'),
             },
             sanitizeFileName: false,
         })


### PR DESCRIPTION
<!--   Thank you for your contribution. Before you submit the pull request:
1. Follow our contribution guidelines
2. Test your changes and attach their results to the pull request.
3. Update the relevant documentation.
-->

**Description**

If react 18 is installed into the project, the generator can get confused and use 18 when transpiling. 
This is a problem as the file `./cjs/react-jsx-runtime.production.min` is not exported by react anymore, resulting in the generation failing:
```
Something went wrong:
Error [ERR_PACKAGE_PATH_NOT_EXPORTED]: Package subpath './cjs/react-jsx-runtime.production.min' is not defined by "exports" in <snip>/node_modules/react/package.json
    at new NodeError (node:internal/errors:399:5)
    at exportsNotFound (node:internal/modules/esm/resolve:361:10)
    at packageExportsResolve (node:internal/modules/esm/resolve:697:9)
    at resolveExports (node:internal/modules/cjs/loader:567:36)
    at Function.Module._findPath (node:internal/modules/cjs/loader:636:31)
    at Function.Module._resolveFilename (node:internal/modules/cjs/loader:1063:27)
    at Function.Module._resolveFilename.sharedData.moduleResolveFilenameHook.installedValue [as _resolveFilename] (<snip>/node_modules/@cspotcode/source-map-support/source-map-support.js:811:30)
    at Function.Module._load (node:internal/modules/cjs/loader:922:27)
    at Module.require (node:internal/modules/cjs/loader:1143:19)
    at require (node:internal/modules/cjs/helpers:110:18)
```

This fixes the issue, by passing the bundler the absolute path to the react file to use, resulting in it always using the react 17 that is a dependency of this library


**Related issue(s)**
<!-- If you refer to a particular issue, provide its number, otherwise, remove this section.
For example, `Resolves #123`, `Fixes #43`, or `See also #33`. The `See also #33` option will not automatically close the issue after the PR merge. -->