### PR TITLE
docs: add notice about source code move

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,12 @@
+# We've Moved! 🚚
+The code for this repo is now a part the AsyncAPI Generator monorepo: https://github.com/asyncapi/generator/tree/master/apps/react-sdk
+
+Please file bugs and feature requests as issues on the AsyncAPI Generator repo: https://github.com/asyncapi/generator/issues
+
+The package name did not change and is still available in npm as: https://www.npmjs.com/package/@asyncapi/generator-react-sdk
+
+---
+
 [![AsyncAPI React SDK](./assets/readme-banner.png)](https://www.asyncapi.com)
 <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
 [![All Contributors](https://img.shields.io/badge/all_contributors-1-orange.svg?style=flat-square)](#contributors-)


### PR DESCRIPTION
part of: https://github.com/asyncapi/generator/issues/1044

react-sdk is now part of the monorepo

<img width="1420" height="976" alt="Image" src="https://github.com/user-attachments/assets/937f74a2-e3ec-4975-a98c-81c625c2d3d7" />

next step for me is to archive https://github.com/asyncapi/generator-react-sdk/ with proper note where the code is now
